### PR TITLE
Navbar getting covered bug resolved

### DIFF
--- a/src/components/CSS/navbar.css
+++ b/src/components/CSS/navbar.css
@@ -9,6 +9,7 @@
   width: 100%;
   box-sizing: border-box;
   position: fixed;
+  z-index:1000;
 }
 
 .navbar-logo-link {


### PR DESCRIPTION
Navbar being covered by main content when we scroll down. By providing z-index:1000 in navbar.css the issue got resolved.